### PR TITLE
Add simple NBA bracket website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # NbaBrackets
-website that allows users to create nba brackets for teams
+
+This project provides a simple website for creating NBA team brackets. It lets you:
+
+- Rank all 30 teams for the regular season by dragging them into order.
+- Pick winners through the playoff rounds until a champion is decided.
+
+To use the site, open `index.html` in a web browser. Rankings are saved to `localStorage` so they persist across visits.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>NBA Bracket Maker</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>NBA Bracket Maker</h1>
+  <section id="regularSeason">
+    <h2>Regular Season Ranking</h2>
+    <p>Drag and drop teams to rank them for the season.</p>
+    <ol id="teamList"></ol>
+    <button id="saveSeason">Save Ranking</button>
+  </section>
+  <section id="playoffs">
+    <h2>Playoffs Bracket</h2>
+    <div class="bracket">
+      <div id="round1" class="round"><h3>Round 1</h3></div>
+      <div id="round2" class="round"><h3>Round 2</h3></div>
+      <div id="round3" class="round"><h3>Conference Finals</h3></div>
+      <div id="round4" class="round"><h3>Finals</h3></div>
+    </div>
+  </section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,128 @@
+const teams = [
+  "Atlanta Hawks", "Boston Celtics", "Brooklyn Nets", "Charlotte Hornets",
+  "Chicago Bulls", "Cleveland Cavaliers", "Dallas Mavericks", "Denver Nuggets",
+  "Detroit Pistons", "Golden State Warriors", "Houston Rockets", "Indiana Pacers",
+  "LA Clippers", "Los Angeles Lakers", "Memphis Grizzlies", "Miami Heat",
+  "Milwaukee Bucks", "Minnesota Timberwolves", "New Orleans Pelicans", "New York Knicks",
+  "Oklahoma City Thunder", "Orlando Magic", "Philadelphia 76ers", "Phoenix Suns",
+  "Portland Trail Blazers", "Sacramento Kings", "San Antonio Spurs", "Toronto Raptors",
+  "Utah Jazz", "Washington Wizards"
+];
+
+let teamOrder = [...teams];
+let dragIndex = null;
+
+function renderTeams() {
+  const list = document.getElementById('teamList');
+  list.innerHTML = '';
+  teamOrder.forEach((team, idx) => {
+    const li = document.createElement('li');
+    li.textContent = team;
+    li.draggable = true;
+    li.dataset.index = idx;
+    li.addEventListener('dragstart', handleDragStart);
+    li.addEventListener('dragover', handleDragOver);
+    li.addEventListener('drop', handleDrop);
+    list.appendChild(li);
+  });
+}
+function handleDragStart(e) {
+  dragIndex = +this.dataset.index;
+}
+function handleDragOver(e) {
+  e.preventDefault();
+}
+function handleDrop(e) {
+  const dropIndex = +this.dataset.index;
+  [teamOrder[dragIndex], teamOrder[dropIndex]] = [teamOrder[dropIndex], teamOrder[dragIndex]];
+  renderTeams();
+}
+
+document.getElementById('saveSeason').addEventListener('click', () => {
+  localStorage.setItem('seasonOrder', JSON.stringify(teamOrder));
+  alert('Regular season ranking saved!');
+});
+
+function loadSeason() {
+  const saved = localStorage.getItem('seasonOrder');
+  if (saved) {
+    try {
+      teamOrder = JSON.parse(saved);
+    } catch {}
+  }
+  renderTeams();
+}
+
+// ----- Playoffs Bracket -----
+const r1Pairs = [
+  ["Bucks", "Heat"],
+  ["Celtics", "Hawks"],
+  ["76ers", "Nets"],
+  ["Cavaliers", "Knicks"],
+  ["Nuggets", "Timberwolves"],
+  ["Grizzlies", "Lakers"],
+  ["Kings", "Warriors"],
+  ["Suns", "Clippers"]
+];
+
+let r1Winners = Array(r1Pairs.length).fill(null);
+let r2Winners = Array(r1Pairs.length/2).fill(null);
+let r3Winners = Array(r1Pairs.length/4).fill(null);
+let champion = null;
+
+function createRound(roundNum, pairs) {
+  const container = document.getElementById(`round${roundNum}`);
+  container.innerHTML = `<h3>${container.querySelector('h3').textContent}</h3>`; // keep heading
+  pairs.forEach((pair, idx) => {
+    const match = document.createElement('div');
+    match.className = 'match';
+    pair.forEach(team => {
+      const btn = document.createElement('button');
+      btn.textContent = team || 'TBD';
+      btn.disabled = !team;
+      btn.addEventListener('click', () => handleWin(roundNum, idx, team));
+      match.appendChild(btn);
+    });
+    container.appendChild(match);
+  });
+}
+
+function handleWin(roundNum, matchIndex, team) {
+  if (roundNum === 1) {
+    r1Winners[matchIndex] = team;
+    if (r1Winners.every(Boolean)) {
+      const next = [
+        [r1Winners[0], r1Winners[1]],
+        [r1Winners[2], r1Winners[3]],
+        [r1Winners[4], r1Winners[5]],
+        [r1Winners[6], r1Winners[7]]
+      ];
+      createRound(2, next);
+    }
+  } else if (roundNum === 2) {
+    r2Winners[matchIndex] = team;
+    if (r2Winners.every(Boolean)) {
+      const next = [
+        [r2Winners[0], r2Winners[1]],
+        [r2Winners[2], r2Winners[3]]
+      ];
+      createRound(3, next);
+    }
+  } else if (roundNum === 3) {
+    r3Winners[matchIndex] = team;
+    if (r3Winners.every(Boolean)) {
+      const next = [[r3Winners[0], r3Winners[1]]];
+      createRound(4, next);
+    }
+  } else if (roundNum === 4) {
+    champion = team;
+    alert(`Champion: ${champion}`);
+  }
+}
+
+function init() {
+  loadSeason();
+  createRound(1, r1Pairs);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,51 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  background: #f4f4f4;
+}
+h1 {
+  text-align: center;
+}
+ol#teamList {
+  list-style: decimal inside;
+  padding: 0;
+  max-width: 300px;
+  margin: auto;
+}
+ol#teamList li {
+  background: white;
+  margin: 5px 0;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  cursor: move;
+}
+button {
+  margin-top: 10px;
+}
+.bracket {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+}
+.round {
+  min-width: 200px;
+}
+.round h3 {
+  text-align: center;
+}
+.match {
+  display: flex;
+  flex-direction: column;
+  margin: 10px 0;
+}
+.match button {
+  margin: 2px 0;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid #666;
+  cursor: pointer;
+}
+.match button:disabled {
+  background: #eee;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- add HTML interface for ranking teams and picking playoff winners
- add basic CSS styling
- add JavaScript logic for drag-and-drop ranking and playoff bracket progression
- update README with usage instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618dc276ec8333beaa1706be7f1a76