### PR TITLE
Add conference-specific ranking lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # NbaBrackets
-website that allows users to create nba brackets for teams
+
+This project provides a simple website for ranking NBA teams in each conference.
+
+You can drag and drop the teams within the Eastern and Western conference lists to rank them from 1–15. Rankings are saved to `localStorage` so they persist across visits.
+
+Open `index.html` in a web browser to try it out.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>NBA Team Rankings</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>NBA Team Rankings</h1>
+  <section id="regularSeason">
+    <h2>Regular Season Ranking</h2>
+    <p>Drag and drop teams within each conference to set the order 1–15.</p>
+    <div id="conferences">
+      <div class="conference">
+        <h3>Eastern Conference</h3>
+        <ol id="eastList" class="teamList"></ol>
+      </div>
+      <div class="conference">
+        <h3>Western Conference</h3>
+        <ol id="westList" class="teamList"></ol>
+      </div>
+    </div>
+    <button id="saveSeason">Save Rankings</button>
+  </section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,78 @@
+// Split teams by conference
+const eastTeams = [
+  "Atlanta Hawks", "Boston Celtics", "Brooklyn Nets", "Charlotte Hornets",
+  "Chicago Bulls", "Cleveland Cavaliers", "Detroit Pistons", "Indiana Pacers",
+  "Miami Heat", "Milwaukee Bucks", "New York Knicks", "Orlando Magic",
+  "Philadelphia 76ers", "Toronto Raptors", "Washington Wizards"
+];
+
+const westTeams = [
+  "Dallas Mavericks", "Denver Nuggets", "Golden State Warriors", "Houston Rockets",
+  "LA Clippers", "Los Angeles Lakers", "Memphis Grizzlies", "Minnesota Timberwolves",
+  "New Orleans Pelicans", "Oklahoma City Thunder", "Phoenix Suns", "Portland Trail Blazers",
+  "Sacramento Kings", "San Antonio Spurs", "Utah Jazz"
+];
+
+let eastOrder = [...eastTeams];
+let westOrder = [...westTeams];
+
+let dragIndex = null;
+let dragList = null;
+
+function renderConference(listId, teamsArray) {
+  const list = document.getElementById(listId);
+  list.innerHTML = '';
+  teamsArray.forEach((team, idx) => {
+    const li = document.createElement('li');
+    li.textContent = team;
+    li.draggable = true;
+    li.dataset.index = idx;
+    li.addEventListener('dragstart', handleDragStart);
+    li.addEventListener('dragover', handleDragOver);
+    li.addEventListener('drop', handleDrop);
+    list.appendChild(li);
+  });
+}
+
+function renderAll() {
+  renderConference('eastList', eastOrder);
+  renderConference('westList', westOrder);
+}
+
+function handleDragStart() {
+  dragIndex = +this.dataset.index;
+  dragList = this.parentElement.id;
+}
+
+function handleDragOver(e) {
+  e.preventDefault();
+}
+
+function handleDrop() {
+  const dropIndex = +this.dataset.index;
+  const listId = this.parentElement.id;
+  if (listId !== dragList) return; // only reorder within same list
+  const arr = listId === 'eastList' ? eastOrder : westOrder;
+  [arr[dragIndex], arr[dropIndex]] = [arr[dropIndex], arr[dragIndex]];
+  renderAll();
+}
+
+function loadRankings() {
+  const eastSaved = localStorage.getItem('eastOrder');
+  const westSaved = localStorage.getItem('westOrder');
+  if (eastSaved) {
+    try { eastOrder = JSON.parse(eastSaved); } catch {}
+  }
+  if (westSaved) {
+    try { westOrder = JSON.parse(westSaved); } catch {}
+  }
+  renderAll();
+}
+
+document.getElementById('saveSeason').addEventListener('click', () => {
+  localStorage.setItem('eastOrder', JSON.stringify(eastOrder));
+  localStorage.setItem('westOrder', JSON.stringify(westOrder));
+  alert('Rankings saved!');
+});
+
+document.addEventListener('DOMContentLoaded', loadRankings);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  background: #f4f4f4;
+}
+h1 {
+  text-align: center;
+}
+#conferences {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+}
+.conference {
+  flex: 1 1 300px;
+  max-width: 300px;
+}
+ol.teamList {
+  list-style: decimal inside;
+  padding: 0;
+}
+ol.teamList li {
+  background: white;
+  margin: 5px 0;
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  cursor: move;
+}
+button {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- split teams into Eastern and Western conferences
- redesign HTML to show two ranking lists
- update JavaScript to handle drag-and-drop within each conference
- simplify styling for the new layout
- update README instructions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68618dc276ec8333beaa1706be7f1a76